### PR TITLE
Add cache clearing script for macOS cache directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,24 @@ Get help: [Post in our discussion board](https://github.com/skills/.github/discu
 &copy; 2023 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)
 
 </footer>
+
+## Cache clearing helper script
+
+Use the provided `scripts/clear_cache.sh` helper to wipe the macOS cache directory located at `/Users/haze/Library/Caches/`.
+
+```bash
+# Preview the files that would be deleted
+bash scripts/clear_cache.sh --dry-run
+
+# Clear the default cache directory
+bash scripts/clear_cache.sh
+
+# Target a custom cache directory
+bash scripts/clear_cache.sh --path /path/to/cache
+```
+
+To have the script run automatically every five minutes, add the following entry to your crontab with `crontab -e`:
+
+```
+*/5 * * * * /bin/bash /full/path/to/scripts/clear_cache.sh >> "$HOME"/clear-cache.log 2>&1
+```

--- a/scripts/clear_cache.sh
+++ b/scripts/clear_cache.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEFAULT_CACHE_DIR="/Users/haze/Library/Caches"
+
+dry_run=false
+cache_dir="$DEFAULT_CACHE_DIR"
+
+print_usage() {
+  cat <<'USAGE'
+Usage: clear_cache.sh [options]
+
+Options:
+  -p, --path DIR   Cache directory to clean (defaults to /Users/haze/Library/Caches)
+  -n, --dry-run    Show what would be deleted without removing anything
+  -h, --help       Display this help message
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -p|--path)
+      if [[ $# -lt 2 ]]; then
+        echo "Error: --path requires a directory argument" >&2
+        exit 1
+      fi
+      cache_dir="$2"
+      shift 2
+      ;;
+    -n|--dry-run)
+      dry_run=true
+      shift
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "Error: Unknown option $1" >&2
+      print_usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -d "$cache_dir" ]]; then
+  echo "Error: Cache directory '$cache_dir' does not exist" >&2
+  exit 1
+fi
+
+if [[ "$cache_dir" == "/" ]]; then
+  echo "Error: Refusing to operate on the root directory" >&2
+  exit 1
+fi
+
+if [[ "$dry_run" == true ]]; then
+  echo "[dry-run] The following items would be removed from $cache_dir:"
+  find "$cache_dir" -mindepth 1 -maxdepth 1
+  exit 0
+fi
+
+find "$cache_dir" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+
+echo "Cleared cache contents in '$cache_dir'."


### PR DESCRIPTION
## Summary
- add a cache-clearing script configured for /Users/haze/Library/Caches
- document how to run the script manually or on a schedule

## Testing
- bash scripts/clear_cache.sh --dry-run --path /tmp

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691176406154832282b420347fa8b5c4)